### PR TITLE
Feature/refactor

### DIFF
--- a/commits_check_config.yaml
+++ b/commits_check_config.yaml
@@ -1,7 +1,4 @@
-additional_commands:
-  database: "^database(\\(.+\\))?:"
-  design: "^design(\\(.+\\))?:"
-
-additional_emojis:
-  database: "🗃️"
-  design: "🎨"
+additional_commit_types:
+  feat:
+      description: Introduce new features.
+      emoji: ✨

--- a/conventional_commits_check/commit_types.yml
+++ b/conventional_commits_check/commit_types.yml
@@ -1,0 +1,304 @@
+commit_types:
+  access:
+    description: Improve accessibility.
+    emoji: ♿️
+
+  analytics:
+    description: Add or update analytics or track code.
+    emoji: 📈
+
+  animation:
+    description: Add or update animations and transitions.
+    emoji: 💫
+
+  arch:
+    description: Make architectural changes.
+    emoji: 🏗️
+
+  assets:
+    description: Add or update assets.
+    emoji: 🍱
+
+  beer:
+    description: Write code drunkenly.
+    emoji: 🍻
+
+  breaking:
+    description: Introduce breaking changes.
+    emoji: 💥
+
+  build:
+    description: Add or update development scripts.
+    emoji: 🔨
+
+  catch:
+    description: Catch errors.
+    emoji: 🥅
+
+  chore:
+    description: Changes that don’t modify src or test files
+    emoji: 💽️
+
+  ci:
+    description: Add or update CI build system.
+    emoji: 👷
+
+  clean:
+    description: Deprecate code that needs to be cleaned up.
+    emoji: 🗑️
+
+  compat:
+    description: Update code due to external API changes.
+    emoji: 👽️
+
+  concurrency:
+    description: Add or update code related to multithreading or concurrency.
+    emoji: 🧵
+
+  config:
+    description: Add or update configuration files.
+    emoji: 🔧
+
+  contrib-add:
+    description: Add or update contributor(s).
+    emoji: 👥
+
+  data:
+    description: Data exploration/inspection.
+    emoji: 🧐
+
+  db:
+    description: Perform database related changes.
+    emoji: 🗃️
+
+  dep-add:
+    description: Add a dependency.
+    emoji: ➕
+
+  dep-rm:
+    description: Remove a dependency.
+    emoji: ➖
+
+  dep-up:
+    description: Add or update compiled files or packages.
+    emoji: 📦️
+
+  deploy:
+    description: Deploy stuff.
+    emoji: 🚀
+
+  docs:
+    description: Add or update documentation.
+    emoji: 📝
+
+  docs-code:
+    description: Add or update comments in source code.
+    emoji: 💡
+
+  downgrade:
+    description: Downgrade dependencies.
+    emoji: ⬇️
+
+  dx:
+    description: Improve developer experience
+    emoji: 🧑‍💻
+
+  egg:
+    description: Add or update an easter egg.
+    emoji: 🥚
+
+  experiment:
+    description: Perform experiments.
+    emoji: ⚗️
+
+  feat:
+    description: Introduce new features.
+    emoji: ✨
+
+  fix:
+    description: Fix a bug.
+    emoji: 🐛
+
+  fix-ci:
+    description: Fix CI Build.
+    emoji: 💚
+
+  flags:
+    description: Add, update, or remove feature flags.
+    emoji: 🚩
+
+  healthcheck:
+    description: Add or update healthcheck.
+    emoji: 🩺
+
+  hotfix:
+    description: Critical hotfix.
+    emoji: 🚑️
+
+  i18n:
+    description: Internationalization and localization.
+    emoji: 🌐
+
+  ignore:
+    description: Add or update a .gitignore file.
+    emoji: 🙈
+
+  inf:
+    description: Infrastructure related changes.
+    emoji: 🧱
+
+  init:
+    description: Begin a project.
+    emoji: 🎉
+
+  iphone:
+    description: Work on responsive design.
+    emoji: 📱
+
+  license:
+    description: Add or update license.
+    emoji: 📄
+
+  lint:
+    description: Fix compiler / linter warnings.
+    emoji: 🚨
+
+  log-add:
+    description: Add or update logs.
+    emoji: 🔊
+
+  log-rm:
+    description: Remove logs.
+    emoji: 🔇
+
+  logic:
+    description: Add or update business logic
+    emoji: 👔
+
+  merge:
+    description: Merge branches.
+    emoji: 🔀
+
+  mock:
+    description: Mock things.
+    emoji: 🤡
+
+  mv:
+    description: Move or rename resources (e.g. files, paths, routes).
+    emoji: 🚚
+
+  patch:
+    description: Simple fix for a non-critical issue.
+    emoji: 🩹
+
+  perf:
+    description: Improve performance.
+    emoji: ⚡️
+
+  poo:
+    description: Write bad code that needs to be improved.
+    emoji: 💩
+
+  prune:
+    description: Remove code or files.
+    emoji: 🔥
+
+  pushpin:
+    description: Pin dependencies to specific versions.
+    emoji: 📌
+
+  refactor:
+    description: Refactor code.
+    emoji: ♻️
+
+  release:
+    description: Release / Version tags.
+    emoji: 🔖
+
+  revert:
+    description: Revert changes.
+    emoji: ⏪️
+
+  rip:
+    description: Remove dead code.
+    emoji: ⚰️
+
+  roles:
+    description: Work on code related to authorization, roles and permissions.
+    emoji: 🛂
+
+  rollforward:
+    description: Create rollforward version.
+    emoji: ⏩️
+
+  run-build:
+    description: Custom type for CI/CD to hook into run build override.
+    emoji: 🚀️
+
+  secrets:
+    description: Add or update secrets.
+    emoji: 🔐
+
+  security:
+    description: Fix security issues.
+    emoji: 🔒️
+
+  seed:
+    description: Add or update seed files.
+    emoji: 🌱
+
+  seo:
+    description: Improve SEO.
+    emoji: 🔍️
+
+  snapshot:
+    description: Add or update snapshots.
+    emoji: 📸
+
+  sponsor:
+    description: Add sponsorships or money related infrastructure.
+    emoji: 💸
+
+  style:
+    description: Improve structure / format of the code.
+    emoji: 🎨
+
+  test:
+    description: Add, update, or pass tests.
+    emoji: ✅
+
+  test-fail:
+    description: Add a failing test.
+    emoji: 🧪
+
+  texts:
+    description: Add or update text and literals.
+    emoji: 💬
+
+  types:
+    description: Add or update types.
+    emoji: 🏷️
+
+  typo:
+    description: Fix typos.
+    emoji: ✏️
+
+  ui:
+    description: Add or update the UI and style files.
+    emoji: 💄
+
+  upgrade:
+    description: Upgrade dependencies.
+    emoji: ⬆️
+
+  ux:
+    description: Improve user experience / usability.
+    emoji: 🚸
+
+  validation:
+    description: Add or update code related to validation.
+    emoji: 🦺
+
+  wip:
+    description: Work in progress.
+    emoji: 🚧

--- a/conventional_commits_check/main.py
+++ b/conventional_commits_check/main.py
@@ -5,86 +5,77 @@ import sys
 import yaml
 import os
 
-COMMIT_TYPES = {
-    "feat": "^feat(\(.+\))?:",
-    "fix": "^fix(\(.+\))?:",
-    "docs": "^docs(\(.+\))?:",
-    "style": "^style(\(.+\))?:",
-    "refactor": "^refactor(\(.+\))?:",
-    "perf": "^perf(\(.+\))?:",
-    "test": "^test(\(.+\))?:",
-    "build": "^build(\(.+\))?:",
-    "ci": "^ci(\(.+\))?:",
-    "chore": "^chore(\(.+\))?:",
-    "revert": "^revert: ",
-}
 
-EMOJIS = {
-    "feat": "✨",
-    "fix": "🐛",
-    "docs": "📚",
-    "style": "💎",
-    "refactor": "🧹",
-    "perf": "🚀",
-    "test": "🧪",
-    "build": "🏗️",
-    "ci": "👷",
-    "chore": "♻️",
-    "revert": "⏪",
-    "merge": "🔀",
-}
+def get_regex_pattern(commit_type: str) -> str:
+    return f"^(. ?)?{commit_type}(\\(.+\\))?\\!?:"
 
 
-def load_custom_rules(config_file="commits_check_config.yaml"):
+
+def load_rules(config_file):
     config_path = os.path.join(os.getcwd(), config_file)
 
     if not os.path.exists(config_path):
-        return {}, {}
+        return {}
 
     with open(config_path, "r") as file:
         config_data = yaml.safe_load(file)
 
-    return config_data.get("additional_commands", {}), config_data.get(
-        "additional_emojis", {}
-    )
+    return config_data.get("additional_commit_types", {})
 
+def get_commit_message(args):
+    with open(args.commit_message_file, "r") as file:
+        return file.read()
+
+def update_commit_message(args, commit_message):
+    with open(args.commit_message_file, "w") as file:
+        file.write(commit_message)
+
+
+def check_commit_message(commit_message, args):
+    commit_types = load_rules("./conventional_commits_check/commit_types.yaml")
+    additional_commands = load_rules("./commits_check_config.yaml")
+    # Merge additional commands and emojis with the existing ones
+    commit_types.update(additional_commands)
+
+
+    commit_type, props = (None, None)
+    for commit_type_for_matching, props in commit_types.items():
+        if re.match(get_regex_pattern(commit_type_for_matching), commit_message.strip()):
+            commit_type, found_props = (commit_type_for_matching, props)
+            break
+
+    if not commit_type:
+        return None, "💥 Commit message does not follow Conventional Commits rules."
+
+    emoji = props["emoji"]
+
+    if emoji and not args.emoji_disabled:
+        if not commit_message.startswith(emoji):
+            index = commit_message.find(commit_type)
+            commit_message = f"{emoji} {commit_message[index:]}"
+
+            return commit_message, "🎉 Commit message follows Conventional Commits rules and has been updated with an emoji."
+
+
+    return commit_message, "🎉 Commit message follows Conventional Commits rules."
 
 def main():
-    additional_commands, additional_emojis = load_custom_rules()
-
-    # Merge additional commands and emojis with the existing ones
-    COMMIT_TYPES.update(additional_commands)
-    EMOJIS.update(additional_emojis)
-
     parser = argparse.ArgumentParser()
     parser.add_argument("commit_message_file")
     parser.add_argument("--emoji-disabled", action="store_true", help="Disable emojis in commit messages")
     args = parser.parse_args()
 
-    with open(args.commit_message_file, "r") as file:
-        commit_message = file.read()
+    commit_message = get_commit_message(args)
 
-    commit_type = None
-    for commit, pattern in COMMIT_TYPES.items():
-        if re.match(pattern, commit_message.strip()):
-            commit_type = commit
-            break
+    (commit_message, result) = check_commit_message(commit_message, args)
 
-    if not commit_type:
-        print("💥 Commit message does not follow Conventional Commits rules.")
+    if commit_message:
+        update_commit_message(args, commit_message)
+        print(result)
+        sys.exit(0)
+    else:
+        print(result)
         sys.exit(1)
-
-    emoji = EMOJIS.get(commit_type)
-
-    if emoji and not args.emoji_disabled:
-        new_commit_message = f"{emoji} {commit_message}"
-        with open(args.commit_message_file, "w") as file:
-            file.write(new_commit_message)
-
-    print(
-        "🎉 Commit message follows Conventional Commits rules and has been updated with an emoji."
-    )
-    sys.exit(0)
 
 
 if __name__ == "__main__":

--- a/conventional_commits_check/test_main.py
+++ b/conventional_commits_check/test_main.py
@@ -1,0 +1,65 @@
+import io
+from unittest import TestCase
+from unittest.mock import patch
+
+from conventional_commits_check.main import main
+
+
+class Test(TestCase):
+    @patch('conventional_commits_check.main.get_commit_message', return_value='✨ feat: this is a sample message')
+    @patch('conventional_commits_check.main.update_commit_message')
+    @patch('sys.exit')
+    @patch('sys.stdout', new_callable=io.StringIO)
+    def test_conventional_commit_with_right_emoji(self,  mock_stdout, mock_exit, mock_get_commit_message, mock_update_commit_message):
+        main()
+
+        self.assertEqual(mock_exit.call_args[0][0], 0)
+        self.assertIn("🎉 Commit message follows Conventional Commits rules.",
+                      mock_stdout.getvalue())
+
+    @patch('conventional_commits_check.main.get_commit_message', return_value='✅ feat: this is a sample message')
+    @patch('conventional_commits_check.main.update_commit_message')
+    @patch('sys.exit')
+    @patch('sys.stdout', new_callable=io.StringIO)
+    def test_conventional_commit_with_wrong_emoji(self,  mock_stdout, mock_exit, mock_get_commit_message, mock_update_commit_message):
+        main()
+
+        self.assertEqual(mock_exit.call_args[0][0], 0)
+        self.assertIn("🎉 Commit message follows Conventional Commits rules and has been updated with an emoji.",
+                      mock_stdout.getvalue())
+
+    @patch('conventional_commits_check.main.get_commit_message', return_value='feat: this is a sample message')
+    @patch('conventional_commits_check.main.update_commit_message')
+    @patch('sys.exit')
+    @patch('sys.stdout', new_callable=io.StringIO)
+    def test_conventional_commit_without_emoji(self, mock_stdout, mock_exit, mock_get_commit_message,
+                                                  mock_update_commit_message):
+        main()
+
+        self.assertEqual(mock_exit.call_args[0][0], 0)
+        self.assertIn("🎉 Commit message follows Conventional Commits rules and has been updated with an emoji.",
+                      mock_stdout.getvalue())
+
+    @patch('conventional_commits_check.main.get_commit_message', return_value='this is a sample message')
+    @patch('conventional_commits_check.main.update_commit_message')
+    @patch('sys.exit')
+    @patch('sys.stdout', new_callable=io.StringIO)
+    def test_non_conventional_commit(self, mock_stdout, mock_exit, mock_get_commit_message,
+                                               mock_update_commit_message):
+        main()
+
+        self.assertEqual(mock_exit.call_args[0][0], 1)
+        self.assertIn("💥 Commit message does not follow Conventional Commits rules.",
+                      mock_stdout.getvalue())
+
+    @patch('conventional_commits_check.main.get_commit_message', return_value='feat(scope): this is a sample message')
+    @patch('conventional_commits_check.main.update_commit_message')
+    @patch('sys.exit')
+    @patch('sys.stdout', new_callable=io.StringIO)
+    def test_scoped_conventional_commit(self, mock_stdout, mock_exit, mock_get_commit_message,
+                                               mock_update_commit_message):
+        main()
+
+        self.assertEqual(mock_exit.call_args[0][0], 0)
+        self.assertIn("🎉 Commit message follows Conventional Commits rules and has been updated with an emoji.",
+                      mock_stdout.getvalue())


### PR DESCRIPTION
Hello!
This is a PR with heavy changes, more oriented to personal choices and needs.

I needed:
- Testability
- Out of the box allowed commit types
- Compatibility with current emojis being used on my repos

What I did:
- Moved the allowed types to a new file and added a bunch
- Simplified the regular expresion, a single one for every type
- Refactored the logic into separate functions
- Added some unit tests

I extracted the commit types form [@JeromeFitz's repo ](https://github.com/JeromeFitz/packages/blob/main/packages/conventional-gitmoji/src/types/releaseRule.ts)
 as I plan to use [the other tools he maintains](https://github.com/JeromeFitz/packages) around conventional commits.

Please, feel free to modify anything you consider better, or even reject the PR if it is too much.
I am eager to hear your comments.
Cheers!